### PR TITLE
[ADD][config/H2-in-memory] config H2 database for deploy Render

### DIFF
--- a/CarShowroom/pom.xml
+++ b/CarShowroom/pom.xml
@@ -129,6 +129,13 @@
 			<version>42.7.4</version>
 		</dependency>
 
+		<!--	H2 for Testing Environment	-->
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
 		<!--	DataSource-Proxy to show log SQL	-->
 		<dependency>
 			<groupId>com.github.gavlyukovskiy</groupId>

--- a/CarShowroom/src/main/java/com/tuantran/CarShowroom/configurations/security/SecurityConfig.java
+++ b/CarShowroom/src/main/java/com/tuantran/CarShowroom/configurations/security/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
             "/v3/api-docs",
             "/swagger-ui/**",
             "/swagger-ui/oauth2-re",
+            "/h2-console/**",
     };
 
     private final String PUBLIC_ENDPOINTS[] = {

--- a/CarShowroom/src/main/resources/application-prod.yaml
+++ b/CarShowroom/src/main/resources/application-prod.yaml
@@ -1,18 +1,37 @@
 spring:
   datasource:
-    #    The database in Render has been suspended, contact me to resume database
-    url: jdbc:postgresql://dpg-d0ca9g15pdvs73de0kng-a.oregon-postgres.render.com:5432/car_showroom_mhue # database in Render
-    driver-class-name: org.postgresql.Driver
-    username: tuantran
-    password: nSBpL43ZbjN1QHoWpUZ9BxjZAmHvs8Fa
+    url: jdbc:h2:mem:car_showroom_db;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: password
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
         format_sql: true
         use_sql_comments: true
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  #spring:
+#  datasource:
+#    #    The database in Render has been suspended, contact me to resume database
+#    url: jdbc:postgresql://dpg-d0ca9g15pdvs73de0kng-a.oregon-postgres.render.com:5432/car_showroom_mhue # database in Render
+#    driver-class-name: org.postgresql.Driver
+#    username: tuantran
+#    password: nSBpL43ZbjN1QHoWpUZ9BxjZAmHvs8Fa
+#  jpa:
+#    hibernate:
+#      ddl-auto: create
+#    show-sql: true
+#    properties:
+#      hibernate:
+#        format_sql: true
+#        use_sql_comments: true
   servlet:
     multipart:
       max-file-size: 10MB


### PR DESCRIPTION
# Using H2 Database for Deployment

**In this project, we configure H2 Database as a lightweight, embedded database for deployment on platforms like Render.**

**Why H2?**

- H2 is a zero-configuration, embedded, in-memory or file-based database.
- It is suitable for testing, demos, or lightweight deployments where a persistent external database (like PostgreSQL or MySQL) is not available.
- H2 can also run in PostgreSQL compatibility mode, which makes migration to a real PostgreSQL database easier later.